### PR TITLE
Remove setting siddhi class path files as Xbootclasspath

### DIFF
--- a/modules/siddhi-launcher/bin/siddhi
+++ b/modules/siddhi-launcher/bin/siddhi
@@ -145,15 +145,6 @@ if [ "$CMD" = "--debug" ]; then
   echo "Please start the remote debugging client to continue..."
 fi
 
-SIDDHI_XBOOTCLASSPATH=""
-for f in "$SIDDHI_HOME"/lib/*.jar
-do
-    if [ "$f" != "$SIDDHI_HOME/lib/*.jar" ];then
-        SIDDHI_XBOOTCLASSPATH="$SIDDHI_XBOOTCLASSPATH":$f
-    fi
-done
-
-
 SIDDHI_CLASSPATH=""
 for f in "$SIDDHI_HOME"/lib/*.jar
 do
@@ -178,7 +169,6 @@ fi
 #   cd "$SIDDHI_HOME"
 
 $JAVACMD \
-	-Xbootclasspath/a:"$SIDDHI_XBOOTCLASSPATH" \
 	-Xms256m -Xmx1024m \
 	-XX:+HeapDumpOnOutOfMemoryError \
 	-XX:HeapDumpPath="$SIDDHI_HOME/heap-dump.hprof" \

--- a/modules/siddhi-launcher/bin/siddhi.bat
+++ b/modules/siddhi-launcher/bin/siddhi.bat
@@ -105,7 +105,7 @@ rem ---------- Add jars to classpath ----------------
 
 set JAVA_ENDORSED="%JAVA_HOME%\jre\lib\endorsed";"%JAVA_HOME%\lib\endorsed"
 
-set CMD_LINE_ARGS=-Xbootclasspath/a:%SIDDHI_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%SIDDHI_HOME%\heap-dump.hprof" -Dcom.sun.management.jmxremote %JAVA_OPTS% -Djava.endorsed.dirs=%JAVA_ENDORSED% -Dsiddhi.home=%SIDDHI_HOME% -classpath %SIDDHI_CLASSPATH% -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Djava.io.tmpdir="%SIDDHI_HOME%\tmp" -Denable.nonblocking=false -Dfile.encoding=UTF8 -Dlog4j.configuration=file:"%SIDDHI_HOME%\conf\log4j.properties"
+set CMD_LINE_ARGS=-Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%SIDDHI_HOME%\heap-dump.hprof" -Dcom.sun.management.jmxremote %JAVA_OPTS% -Djava.endorsed.dirs=%JAVA_ENDORSED% -Dsiddhi.home=%SIDDHI_HOME% -classpath %SIDDHI_CLASSPATH% -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Djava.io.tmpdir="%SIDDHI_HOME%\tmp" -Denable.nonblocking=false -Dfile.encoding=UTF8 -Dlog4j.configuration=file:"%SIDDHI_HOME%\conf\log4j.properties"
 
 :runJava
 "%JAVA_HOME%\bin\java" %CMD_LINE_ARGS% org.wso2.siddhi.sdk.launcher.Main %CMD%


### PR DESCRIPTION
## Purpose
This removes setting siddhi class path files(all the jar files in lib folder) as the Xbootclasspath.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes